### PR TITLE
feat: make moduleName deprecated, componentName to replace it

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ function HostApp() {
     <View>
       <Button onPress={sendMessageToSandbox} title="Send to Sandbox" />
       <SandboxReactNativeView ref={sandboxRef}
-        moduleName={"ModuleName"} // The name of your JS module
+        componentName={"ModuleName"} // The name of your JS component
         jsBundleSource={"sandbox"} // The JS bundle: file name or URL
         onMessage={handleMessage}
         onError={handleError}

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ function HostApp() {
     <View>
       <Button onPress={sendMessageToSandbox} title="Send to Sandbox" />
       <SandboxReactNativeView ref={sandboxRef}
-        componentName={"ModuleName"} // The name of your JS component
         jsBundleSource={"sandbox"} // The JS bundle: file name or URL
+        componentName={"SandboxApp"} // The name of your JS component from jsBundleSource
         onMessage={handleMessage}
         onError={handleError}
       />
@@ -108,7 +108,7 @@ function HostApp() {
 import React, { useState, useEffect, useCallback } from 'react';
 import { View, Button, Text } from 'react-native';
 
-// No import required API available through global
+// No import required, API available through global
 declare global {
   var postMessage: (message: object) => void;
   var setOnMessage: (handler: (payload: object) => void) => void;

--- a/apps/demo/App.tsx
+++ b/apps/demo/App.tsx
@@ -18,7 +18,7 @@ const SideBySideDemo: React.FC = () => {
           <SandboxReactNativeView
             style={styles.sandboxView}
             jsBundleSource={'sandbox'}
-            moduleName={'CrashIfYouCanDemo'}
+            componentName={'CrashIfYouCanDemo'}
             onError={error => {
               const message = `Got ${error.isFatal ? 'fatal' : 'non-fatal'} error from sandbox`
               console.warn(message, error)

--- a/apps/demo/App.tsx
+++ b/apps/demo/App.tsx
@@ -17,8 +17,8 @@ const SideBySideDemo: React.FC = () => {
           <Text style={styles.header}>Sandboxed</Text>
           <SandboxReactNativeView
             style={styles.sandboxView}
-            jsBundleSource={'sandbox'}
-            componentName={'CrashIfYouCanDemo'}
+            jsBundleSource={'sandbox'} // bundle name for query from metro
+            componentName={'SandboxedDemo'} // componentName from sandbox.js
             onError={error => {
               const message = `Got ${error.isFatal ? 'fatal' : 'non-fatal'} error from sandbox`
               console.warn(message, error)

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "start": "react-native start"
+    "start": "react-native start",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "react": "19.1.0",

--- a/apps/demo/sandbox.js
+++ b/apps/demo/sandbox.js
@@ -4,4 +4,4 @@ import CrashIfYouCanDemo from './CrashIfYouCanDemo'
 
 LogBox.uninstall()
 
-AppRegistry.registerComponent('CrashIfYouCanDemo', () => CrashIfYouCanDemo)
+AppRegistry.registerComponent('SandboxedDemo', () => CrashIfYouCanDemo)

--- a/apps/fs-experiment/App.tsx
+++ b/apps/fs-experiment/App.tsx
@@ -177,7 +177,7 @@ function App(): React.JSX.Element {
                 styles.sandbox,
                 {backgroundColor: theme.background, borderColor: theme.border},
               ]}
-              moduleName={'AppFS'}
+              componentName={'AppFS'}
               jsBundleSource="sandbox-fs"
               allowedTurboModules={['RNFSManager', 'FileReaderModule']}
               onMessage={message => {
@@ -207,7 +207,7 @@ function App(): React.JSX.Element {
                 styles.sandbox,
                 {backgroundColor: theme.background, borderColor: theme.border},
               ]}
-              moduleName={'AppFileAccess'}
+              componentName={'AppFileAccess'}
               allowedTurboModules={['FileAccess']}
               jsBundleSource="sandbox-file-access"
               onMessage={message => {

--- a/apps/fs-experiment/App.tsx
+++ b/apps/fs-experiment/App.tsx
@@ -177,8 +177,8 @@ function App(): React.JSX.Element {
                 styles.sandbox,
                 {backgroundColor: theme.background, borderColor: theme.border},
               ]}
-              componentName={'AppFS'}
-              jsBundleSource="sandbox-fs"
+              componentName={'AppFS'} // componentName from sandbox-fs.js
+              jsBundleSource="sandbox-fs" // bundle name for query from metro
               allowedTurboModules={['RNFSManager', 'FileReaderModule']}
               onMessage={message => {
                 console.log('Host received message from sandbox:', message)
@@ -207,9 +207,9 @@ function App(): React.JSX.Element {
                 styles.sandbox,
                 {backgroundColor: theme.background, borderColor: theme.border},
               ]}
-              componentName={'AppFileAccess'}
+              componentName={'AppFileAccess'} // componentName from sandbox-file-access.js
               allowedTurboModules={['FileAccess']}
-              jsBundleSource="sandbox-file-access"
+              jsBundleSource="sandbox-file-access" // bundle name for query from metro
               onMessage={message => {
                 console.log('Host received message from sandbox:', message)
               }}

--- a/apps/fs-experiment/package.json
+++ b/apps/fs-experiment/package.json
@@ -8,7 +8,8 @@
     "start": "react-native start",
     "bundle:sandbox": "bun run bundle:sandbox-fs && bun run bundle:sandbox-file-access",
     "bundle:sandbox-fs": "npx react-native bundle --platform ios --dev false --entry-file sandbox-fs.js --bundle-output ios/sandbox-fs.jsbundle --assets-dest ios/",
-    "bundle:sandbox-file-access": "npx react-native bundle --platform ios --dev false --entry-file sandbox-file-access.js --bundle-output ios/sandbox-file-access.jsbundle --assets-dest ios/"
+    "bundle:sandbox-file-access": "npx react-native bundle --platform ios --dev false --entry-file sandbox-file-access.js --bundle-output ios/sandbox-file-access.jsbundle --assets-dest ios/",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "react": "19.1.0",

--- a/apps/recursive/App.tsx
+++ b/apps/recursive/App.tsx
@@ -100,7 +100,7 @@ function App({depth = 1}: AppProps): React.JSX.Element {
               <SandboxReactNativeView
                 style={styles.recursiveSandbox}
                 jsBundleSource="index"
-                moduleName="App" // Recursively load App itself
+                componentName="App" // Recursively load App itself
                 initialProperties={{depth: depth + 1}}
                 onMessage={msg => console.log('message', msg)}
                 onError={e => console.error('error', e)}

--- a/apps/recursive/App.tsx
+++ b/apps/recursive/App.tsx
@@ -99,8 +99,8 @@ function App({depth = 1}: AppProps): React.JSX.Element {
               </Text>
               <SandboxReactNativeView
                 style={styles.recursiveSandbox}
-                jsBundleSource="index"
-                componentName="App" // Recursively load App itself
+                jsBundleSource="index" // bundle name for query from metro
+                componentName="App" // Recursively load App component from index.js
                 initialProperties={{depth: depth + 1}}
                 onMessage={msg => console.log('message', msg)}
                 onError={e => console.error('error', e)}

--- a/apps/recursive/RecursiveDisplay.tsx
+++ b/apps/recursive/RecursiveDisplay.tsx
@@ -19,7 +19,7 @@ const RecursiveDisplay = ({depth}: Props) => {
       {depth < MAX_DEPTH ? (
         <SandboxReactNativeView
           style={styles.flex}
-          moduleName="RecursiveDisplay"
+          componentName="RecursiveDisplay"
           initialProperties={{depth: depth + 1}}
         />
       ) : (

--- a/apps/recursive/package.json
+++ b/apps/recursive/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "start": "react-native start"
+    "start": "react-native start",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "react": "19.1.0",

--- a/apps/side-by-side/App.tsx
+++ b/apps/side-by-side/App.tsx
@@ -44,8 +44,8 @@ function SandboxDemoView({initialProperties}: {initialProperties: any}) {
         {isVisible ? (
           <SandboxReactNativeView
             ref={sandboxRef}
-            jsBundleSource={'sandbox'}
-            componentName={'SandboxApp'}
+            jsBundleSource={'sandbox'} // bundle name for query from metro
+            componentName={'SandboxApp'} // componentName registered in sandbox.js
             style={styles.sandboxView}
             initialProperties={initialProperties}
             onMessage={msg => {

--- a/apps/side-by-side/App.tsx
+++ b/apps/side-by-side/App.tsx
@@ -45,7 +45,7 @@ function SandboxDemoView({initialProperties}: {initialProperties: any}) {
           <SandboxReactNativeView
             ref={sandboxRef}
             jsBundleSource={'sandbox'}
-            moduleName={'SandboxApp'}
+            componentName={'SandboxApp'}
             style={styles.sandboxView}
             initialProperties={initialProperties}
             onMessage={msg => {

--- a/apps/side-by-side/package.json
+++ b/apps/side-by-side/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "start": "react-native start"
+    "start": "react-native start",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "react": "19.1.0",

--- a/bun.lock
+++ b/bun.lock
@@ -121,7 +121,7 @@
     },
     "packages/react-native-sandbox": {
       "name": "@callstack/react-native-sandbox",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "react": "19.1.0",
         "react-native": "0.80.1",

--- a/docs/article.md
+++ b/docs/article.md
@@ -60,7 +60,7 @@ On API level you will deal with `SandboxReactNativeView` component in your JSX:
 <SandboxReactNativeView
   style={styles.sandboxContainer}
   jsBundleSource={'my-plugin'}
-  moduleName={'PluginComponent'}
+  componentName={'PluginComponent'}
   onMessage={(message) => {
     console.log(`Message: ${message} received through safe API`)
   }}
@@ -105,7 +105,7 @@ On the left, you'll see the "Main App" column running a component directly in th
     <SandboxReactNativeView
       style={styles.sandboxView}
       jsBundleSource={'sandbox'}
-      moduleName={'CrashIfYouCanDemo'}
+      componentName={'CrashIfYouCanDemo'}
       onError={error => {
         Toast.show({...})
         return false

--- a/docs/presentation.md
+++ b/docs/presentation.md
@@ -74,7 +74,7 @@ function App() {
       ...
       <SandboxReactNativeView ref={sandbox1Ref}
         jsBundleSource={"sandbox"}
-        moduleName={"SandboxApp"}
+        componentName={"SandboxApp"}
         onMessage={onMessage}
         onError={onError}
         initialProperties={...} launchOptions={...} />
@@ -179,7 +179,7 @@ function App() {
       ...
       <SandboxReactNativeView ref={sandbox1Ref}
         jsBundleSource={"sandbox"}
-        moduleName={"SandboxApp"}
+        componentName={"SandboxApp"}
         onMessage={onMessage}
         onError={onError}
         initialProperties={...} launchOptions={...} />

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "android": "bun run android --filter=@apps/side-by-side",
     "lint": "eslint . && bun --filter=@callstack/react-native-sandbox lint",
     "format": "eslint . --fix && bun --filter=@callstack/react-native-sandbox format",
+    "typecheck": "bun --filter=@callstack/react-native-sandbox typecheck",
     "test": "jest"
   },
   "devDependencies": {

--- a/packages/react-native-sandbox/README.md
+++ b/packages/react-native-sandbox/README.md
@@ -33,7 +33,7 @@ The package uses **autolinking** and supports the **React Native New Architectur
 import SandboxReactNativeView from '@callstack/react-native-sandbox';
 
 <SandboxReactNativeView
-  moduleName="YourSandboxModule"
+  componentName="YourSandboxModule"
   jsBundleSource="sandbox" // bundle file name
   onMessage={(data) => console.log('From sandbox:', data)}
   onError={(error) => console.error('Sandbox error:', error)}
@@ -46,7 +46,8 @@ import SandboxReactNativeView from '@callstack/react-native-sandbox';
 
 | Prop | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `moduleName` | `string` | :ballot_box_with_check: | - | Name of the registered component to load from bundle specified in `jsBundleSource` |
+| `componentName` | `string` | :ballot_box_with_check: | - | Name of the registered component to load from bundle specified in `jsBundleSource` |
+| `moduleName` | `string` | :white_large_square: | - | **⚠️ Deprecated**: Use `componentName` instead. Will be removed in a future version. |
 | `jsBundleSource` | `string` | :ballot_box_with_check: | - | Name on file storage or URL to the JavaScript bundle to load |
 | `initialProperties` | `object` | :white_large_square: | `{}` | Initial props for the sandboxed app |
 | `launchOptions` | `object` | :white_large_square: | `{}` | Launch configuration options |
@@ -157,7 +158,7 @@ useEffect(() => {
 
 return (
   <SandboxReactNativeView
-    moduleName="DynamicApp"
+    componentName="DynamicApp"
     jsBundleSource={bundleUrl}
     initialProperties={{ 
       userId: currentUser.id,
@@ -262,7 +263,7 @@ Enable additional logging:
 const isDebug = __DEV__;
 
 <SandboxReactNativeView
-  moduleName="DebugApp"
+  componentName="DebugApp"
   launchOptions={{ debug: isDebug }}
   onError={(error) => {
     if (isDebug) {

--- a/packages/react-native-sandbox/README.md
+++ b/packages/react-native-sandbox/README.md
@@ -46,7 +46,7 @@ import SandboxReactNativeView from '@callstack/react-native-sandbox';
 
 | Prop | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `componentName` | `string` | :ballot_box_with_check: | - | Name of the registered component to load from bundle specified in `jsBundleSource` |
+| `componentName` | `string` | :ballot_box_with_check: | - | Name of the component registered through `AppRegistry.registerComponent` call inside the bundle file specified in `jsBundleSource` |
 | `moduleName` | `string` | :white_large_square: | - | **⚠️ Deprecated**: Use `componentName` instead. Will be removed in a future version. |
 | `jsBundleSource` | `string` | :ballot_box_with_check: | - | Name on file storage or URL to the JavaScript bundle to load |
 | `initialProperties` | `object` | :white_large_square: | `{}` | Initial props for the sandboxed app |

--- a/packages/react-native-sandbox/README.md
+++ b/packages/react-native-sandbox/README.md
@@ -33,7 +33,7 @@ The package uses **autolinking** and supports the **React Native New Architectur
 import SandboxReactNativeView from '@callstack/react-native-sandbox';
 
 <SandboxReactNativeView
-  componentName="YourSandboxModule"
+  componentName="YourSandboxComponent"
   jsBundleSource="sandbox" // bundle file name
   onMessage={(data) => console.log('From sandbox:', data)}
   onError={(error) => console.error('Sandbox error:', error)}

--- a/packages/react-native-sandbox/ios/SandboxReactNativeViewComponentView.mm
+++ b/packages/react-native-sandbox/ios/SandboxReactNativeViewComponentView.mm
@@ -47,7 +47,7 @@ using namespace facebook::react;
 
   bool shouldReload = false;
 
-  if (oldViewProps.moduleName != newViewProps.moduleName ||
+  if (oldViewProps.componentName != newViewProps.componentName ||
       oldViewProps.jsBundleSource != newViewProps.jsBundleSource ||
       oldViewProps.initialProperties != newViewProps.initialProperties ||
       oldViewProps.launchOptions != newViewProps.launchOptions ||
@@ -93,10 +93,10 @@ using namespace facebook::react;
 {
   const auto &props = *std::static_pointer_cast<const SandboxReactNativeViewProps>(_props);
 
-  NSString *moduleName = RCTNSStringFromString(props.moduleName);
+  NSString *componentName = RCTNSStringFromString(props.componentName);
   NSString *jsBundleSource = RCTNSStringFromString(props.jsBundleSource);
 
-  if (moduleName.length == 0 || jsBundleSource.length == 0) {
+  if (componentName.length == 0 || jsBundleSource.length == 0) {
     return;
   }
 
@@ -131,7 +131,7 @@ using namespace facebook::react;
   delegate.hasOnErrorHandler = props.hasOnErrorHandler;
 
   RCTReactNativeFactory *factory = [[RCTReactNativeFactory alloc] initWithDelegate:delegate];
-  UIView *rnView = [factory.rootViewFactory viewWithModuleName:moduleName
+  UIView *rnView = [factory.rootViewFactory viewWithModuleName:componentName
                                              initialProperties:initialProperties
                                                  launchOptions:launchOptions];
 

--- a/packages/react-native-sandbox/specs/NativeSandboxReactNativeView.ts
+++ b/packages/react-native-sandbox/specs/NativeSandboxReactNativeView.ts
@@ -39,10 +39,10 @@ export interface MessageEvent {
  */
 export interface NativeProps extends ViewProps {
   /**
-   * The name of the React Native module to load in the sandbox.
+   * The name of the React Native component to load in the sandbox.
    * Must match with the registered component name from the JavaScript bundle
    */
-  moduleName: string
+  componentName: string
 
   /** Name on file storage or URL to the JavaScript bundle to load */
   jsBundleSource: string

--- a/packages/react-native-sandbox/src/index.tsx
+++ b/packages/react-native-sandbox/src/index.tsx
@@ -58,10 +58,17 @@ type GenericProps = {
  */
 export type SandboxReactNativeViewProps = ViewProps & {
   /**
+   * The name of the React Native component to load in the sandbox.
+   * This should match the component name registered in your JavaScript bundle.
+   */
+  componentName: string
+
+  /**
+   * @deprecated Use componentName instead. Will be removed in a future version.
    * The name of the React Native module to load in the sandbox.
    * This should match the component name registered in your JavaScript bundle.
    */
-  moduleName: string
+  moduleName?: string
 
   /**
    * Optional path or URL to the JavaScript bundle to load.
@@ -158,7 +165,7 @@ export interface SandboxReactNativeViewRef {
  *   return (
  *     <SandboxReactNativeView
  *       ref={sandboxRef}
- *       moduleName="MyDynamicApp"
+ *       componentName="MyDynamicApp"
  *       jsBundleSource="https://example.com/app.bundle.js"
  *       initialProperties={{ userId: '123', theme: 'dark' }}
  *       onMessage={handleMessage}
@@ -173,7 +180,7 @@ export interface SandboxReactNativeViewRef {
  * Advanced usage with custom TurboModules:
  * ```tsx
  * <SandboxReactNativeView
- *   moduleName="SecureApp"
+ *   componentName="SecureApp"
  *   allowedTurboModules={['MyCustomModule', 'CryptoModule']}
  *   launchOptions={{ debugMode: false, securityLevel: 'high' }}
  *   onMessage={(data) => {
@@ -188,78 +195,116 @@ export interface SandboxReactNativeViewRef {
 const SandboxReactNativeView = forwardRef<
   SandboxReactNativeViewRef,
   SandboxReactNativeViewProps
->(({onMessage, onError, allowedTurboModules, style, ...rest}, ref) => {
-  const nativeRef =
-    useRef<React.ElementRef<NativeSandboxReactNativeViewComponentType> | null>(
-      null
+>(
+  (
+    {
+      onMessage,
+      onError,
+      allowedTurboModules,
+      style,
+      componentName,
+      moduleName,
+      ...rest
+    },
+    ref
+  ) => {
+    const nativeRef =
+      useRef<React.ElementRef<NativeSandboxReactNativeViewComponentType> | null>(
+        null
+      )
+
+    const postMessage = useCallback((message: any) => {
+      if (nativeRef.current) {
+        Commands.postMessage(nativeRef.current, JSON.stringify(message))
+      }
+    }, [])
+
+    const _onError = useCallback(
+      (e: NativeSyntheticEvent<ErrorEvent>) => {
+        // @ts-ignore
+        onError?.(e.nativeEvent as ErrorEvent)
+      },
+      [onError]
     )
 
-  const postMessage = useCallback((message: any) => {
-    if (nativeRef.current) {
-      Commands.postMessage(nativeRef.current, JSON.stringify(message))
-    }
-  }, [])
-
-  const _onError = useCallback(
-    (e: NativeSyntheticEvent<ErrorEvent>) => {
-      // @ts-ignore
-      onError?.(e.nativeEvent as ErrorEvent)
-    },
-    [onError]
-  )
-
-  const _onMessage = useCallback(
-    (e: NativeSyntheticEvent<MessageEvent>) => {
-      // @ts-ignore
-      onMessage?.(e.nativeEvent.data)
-    },
-    [onMessage]
-  )
-
-  useImperativeHandle(
-    ref,
-    () => ({
-      postMessage,
-    }),
-    [postMessage]
-  )
-
-  const _renderOverlay = useCallback(() => {
-    // TODO implement some loading/error/handling screen
-    return null
-  }, [])
-
-  const _style: StyleProp<ViewStyle> = useMemo(
-    () => ({
-      ...StyleSheet.absoluteFillObject,
-    }),
-    []
-  )
-
-  const _allowedTurboModules = [
-    ...new Set([
-      ...(allowedTurboModules ?? []),
-      ...SANDBOX_TURBOMODULES_WHITELIST,
-    ]),
-  ]
-
-  return (
-    <View style={style}>
-      <NativeSandboxReactNativeView
+    const _onMessage = useCallback(
+      (e: NativeSyntheticEvent<MessageEvent>) => {
         // @ts-ignore
-        ref={nativeRef}
-        hasOnMessageHandler={!!onMessage}
-        hasOnErrorHandler={!!onError}
-        onError={onError ? _onError : undefined}
-        onMessage={onMessage ? _onMessage : undefined}
-        allowedTurboModules={_allowedTurboModules}
-        style={_style}
-        {...rest}
-      />
-      {_renderOverlay()}
-    </View>
-  )
-})
+        onMessage?.(e.nativeEvent.data)
+      },
+      [onMessage]
+    )
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        postMessage,
+      }),
+      [postMessage]
+    )
+
+    const _renderOverlay = useCallback(() => {
+      // TODO implement some loading/error/handling screen
+      return null
+    }, [])
+
+    const _style: StyleProp<ViewStyle> = useMemo(
+      () => ({
+        ...StyleSheet.absoluteFillObject,
+      }),
+      []
+    )
+
+    const _allowedTurboModules = [
+      ...new Set([
+        ...(allowedTurboModules ?? []),
+        ...SANDBOX_TURBOMODULES_WHITELIST,
+      ]),
+    ]
+
+    // Handle backward compatibility for moduleName -> componentName
+    const resolvedComponentName = useMemo(() => {
+      if (componentName && moduleName) {
+        console.warn(
+          'Both componentName and moduleName are provided. Using componentName and ignoring moduleName. ' +
+            'Please migrate to using componentName only as moduleName is deprecated.'
+        )
+        return componentName
+      }
+
+      if (moduleName) {
+        console.warn(
+          'moduleName is deprecated. Please use componentName instead. moduleName will be removed in a future version.'
+        )
+        return moduleName
+      }
+
+      if (!componentName) {
+        throw new Error('Either componentName or moduleName must be provided')
+      }
+
+      return componentName
+    }, [componentName, moduleName])
+
+    return (
+      <View style={style}>
+        <NativeSandboxReactNativeView
+          // @ts-ignore
+          ref={nativeRef}
+          componentName={resolvedComponentName}
+          hasOnMessageHandler={!!onMessage}
+          hasOnErrorHandler={!!onError}
+          onError={onError ? _onError : undefined}
+          onMessage={onMessage ? _onMessage : undefined}
+          allowedTurboModules={_allowedTurboModules}
+          style={_style}
+          {...rest}
+        />
+        {_renderOverlay()}
+      </View>
+    )
+  }
+)
 
 SandboxReactNativeView.displayName = 'SandboxReactNativeView'
 export default SandboxReactNativeView

--- a/packages/react-native-sandbox/src/index.tsx
+++ b/packages/react-native-sandbox/src/index.tsx
@@ -65,7 +65,7 @@ export type SandboxReactNativeViewProps = ViewProps & {
 
   /**
    * @deprecated Use componentName instead. Will be removed in a future version.
-   * The name of the React Native module to load in the sandbox.
+   * The name of the React Native component to load in the sandbox.
    * This should match the component name registered in your JavaScript bundle.
    */
   moduleName?: string

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
     "allowJs": true,
     "esModuleInterop": true,
     "paths": {
-      "@react-native-ai/mlc": ["./packages/mlc/src/index"],
-      "@react-native-ai/apple": ["./packages/apple-llm/src"]
+      "@callstack/react-native-sandbox": ["./packages/react-native-sandbox/src/index"],
     },
     "jsx": "react-native",
     "lib": ["DOM", "ESNext"],


### PR DESCRIPTION
`moduleName` mostly used on native side and doesn't reflect actual propose of it.

`componentName` seems better, simply because it it's the same name that used in `AppRegistry.registerComponent`

This PR basically to get opinion on this change and hear pros and cons