### PR TITLE
fix: prevent overflow crash on older android versions

### DIFF
--- a/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
+++ b/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
@@ -389,7 +389,7 @@ class SandboxReactNativeDelegate(
          * returns `this` in SandboxContextWrapper, that causes infinite recursion and a
          * StackOverflowError. Android 13+ fixed this in ContextWrapper by delegating to mBase 
          * directly. We mirror that fix here to support older platforms.
-         * /
+         */
         override fun registerComponentCallbacks(callback: android.content.ComponentCallbacks) {
             baseContext.applicationContext.registerComponentCallbacks(callback)
         }

--- a/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
+++ b/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
@@ -382,6 +382,21 @@ class SandboxReactNativeDelegate(
         override fun getFilesDir(): java.io.File = sandboxFilesDir
 
         override fun getApplicationContext(): Context = this
+
+        /**
+         * On Android 12 and below, Context.registerComponentCallbacks() delegates to
+         * getApplicationContext().registerComponentCallbacks(). Since getApplicationContext()
+         * returns `this` in SandboxContextWrapper, that causes infinite recursion and a
+         * StackOverflowError. Android 13+ fixed this in ContextWrapper by delegating to mBase 
+         * directly. We mirror that fix here to support older platforms.
+         * /
+        override fun registerComponentCallbacks(callback: android.content.ComponentCallbacks) {
+            baseContext.applicationContext.registerComponentCallbacks(callback)
+        }
+
+        override fun unregisterComponentCallbacks(callback: android.content.ComponentCallbacks) {
+            baseContext.applicationContext.unregisterComponentCallbacks(callback)
+        }
     }
 
     private class FilteredReactPackage(

--- a/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
+++ b/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
@@ -387,7 +387,7 @@ class SandboxReactNativeDelegate(
          * On Android 12 and below, Context.registerComponentCallbacks() delegates to
          * getApplicationContext().registerComponentCallbacks(). Since getApplicationContext()
          * returns `this` in SandboxContextWrapper, that causes infinite recursion and a
-         * StackOverflowError. Android 13+ fixed this in ContextWrapper by delegating to mBase 
+         * StackOverflowError. Android 13+ fixed this in ContextWrapper by delegating to mBase
          * directly. We mirror that fix here to support older platforms.
          */
         override fun registerComponentCallbacks(callback: android.content.ComponentCallbacks) {


### PR DESCRIPTION
Addresses https://github.com/callstackincubator/react-native-sandbox/issues/25