### PR TITLE
fix(android): embedded surface renders with zero height on RN 0.85

### DIFF
--- a/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeView.kt
+++ b/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeView.kt
@@ -78,7 +78,21 @@ class SandboxReactNativeView(
         val w = right - left
         val h = bottom - top
         for (i in 0 until childCount) {
-            getChildAt(i).layout(0, 0, w, h)
+            val child = getChildAt(i)
+            // The child is a ReactSurfaceView from a SEPARATE ReactHost. Fabric
+            // lays our view out by calling layout() directly, without a measure
+            // pass, so the child never receives onMeasure(). But ReactSurfaceView
+            // only pushes layout constraints to its surface from onMeasure() (and
+            // its onLayout() is a no-op until wasMeasured is true). Without an
+            // explicit measure the nested surface keeps its initial constructor
+            // constraints and renders blank (regression surfaced on RN 0.85).
+            // Measure with EXACTLY specs so updateLayoutSpecs() runs with our real
+            // size, then lay the child out to fill us.
+            child.measure(
+                MeasureSpec.makeMeasureSpec(w, MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(h, MeasureSpec.EXACTLY),
+            )
+            child.layout(0, 0, w, h)
         }
     }
 

--- a/packages/react-native-sandbox/src/index.tsx
+++ b/packages/react-native-sandbox/src/index.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
 } from 'react'
 import type {NativeSyntheticEvent} from 'react-native'
-import {StyleProp, StyleSheet, View, ViewProps, ViewStyle} from 'react-native'
+import {StyleProp, View, ViewProps, ViewStyle} from 'react-native'
 
 import type {NativeSandboxReactNativeViewComponentType} from '../specs/NativeSandboxReactNativeView'
 import NativeSandboxReactNativeView, {
@@ -305,9 +305,14 @@ const SandboxReactNativeView = forwardRef<
       return null
     }, [])
 
+    // The native sandbox view fills the user-styled wrapper as an in-flow
+    // flex child. It used to be position:absolute (StyleSheet.absoluteFillObject),
+    // but on RN 0.85 an absolutely-positioned child with all-zero insets no longer
+    // stretches to a flex-sized parent — it collapses to height 0 and the embedded
+    // surface renders blank. flex:1 makes it claim the wrapper's space reliably.
     const _style: StyleProp<ViewStyle> = useMemo(
       () => ({
-        ...StyleSheet.absoluteFillObject,
+        flex: 1,
       }),
       []
     )


### PR DESCRIPTION
## Summary

On **RN 0.85** the embedded sandbox surface stays blank on Android: the bundle runs (`Running "<name>"` shows in the log) but the native `SandboxReactNativeView` is laid out with **height 0** (width still fills via the parent's default `alignItems: stretch`, which masks the problem). The lib works on RN 0.80 — this is a 0.85 regression.

Two independent causes, both fixed:

1. **`absoluteFillObject` collapses to height 0.** The native view is rendered as `position:absolute` (`StyleSheet.absoluteFillObject`) inside the user-styled `<View>` wrapper. On RN 0.85 an absolutely-positioned child with all-zero insets (`top/left/right/bottom: 0`) no longer stretches to a flex-sized parent — it collapses to height 0. Making it an **in-flow `flex: 1`** child makes it reliably claim the wrapper's space.

2. **Nested `ReactSurfaceView` never measured.** `onLayout` positioned the child with `layout()` but never called `measure()`. `ReactSurfaceView` only pushes layout constraints to its surface from `onMeasure()` (its `onLayout()` is a no-op until `wasMeasured` is true), so the nested surface kept its initial constructor constraints and rendered blank. We now `measure()` the child with `EXACTLY` specs before laying it out, so `updateLayoutSpecs()` runs with the real size.

## Test plan

Verified on a device (RN 0.85.3 / React 19.2.3, New Architecture, Android/Waydroid x86_64): the embedded surface renders, lays out to fill its container, and receives touches. Before the change `onLayout` reported `w=742 h=0`; after, `w=742 h=919` and the surface paints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)