### PR TITLE
fix(android): touch interceptor treats box-none dev overlay as obscuring → sandbox untappable in debug

### DIFF
--- a/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxTouchInterceptor.kt
+++ b/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxTouchInterceptor.kt
@@ -6,6 +6,8 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
+import com.facebook.react.uimanager.PointerEvents
+import com.facebook.react.views.view.ReactViewGroup
 import java.lang.ref.WeakReference
 
 /**
@@ -338,16 +340,31 @@ object SandboxTouchInterceptor {
                 if (!isDrawnAfter(group, i, childIndex)) continue
                 if (sibling.visibility != View.VISIBLE) continue
 
-                // Check the sibling's own bounds
-                sibling.getLocationOnScreen(siblingLoc)
-                val sibRect =
-                    Rect(
-                        siblingLoc[0],
-                        siblingLoc[1],
-                        siblingLoc[0] + sibling.width,
-                        siblingLoc[1] + sibling.height,
-                    )
-                if (sibRect.contains(screenX, screenY)) return true
+                // A view with pointerEvents NONE/BOX_NONE does not consume touch in
+                // its own box, so it does not obscure. This matters in debug builds:
+                // React Native's AppContainer adds a full-screen pointerEvents
+                // "box-none" overlay (for LogBox/the element inspector) drawn on top
+                // of everything. Without this check it is treated as an overlay and
+                // steals every touch that lands in a sandbox — the sandbox becomes
+                // untappable in dev (release has no such overlay, so it only repros
+                // in debug, which makes it easy to miss).
+                val pointerEvents = (sibling as? ReactViewGroup)?.pointerEvents
+                if (pointerEvents == PointerEvents.NONE) continue
+
+                // Check the sibling's own bounds — only if the view itself catches
+                // touch. BOX_NONE lets the touch pass through its own box (only its
+                // children can catch), so skip the own-bounds test for it.
+                if (pointerEvents != PointerEvents.BOX_NONE) {
+                    sibling.getLocationOnScreen(siblingLoc)
+                    val sibRect =
+                        Rect(
+                            siblingLoc[0],
+                            siblingLoc[1],
+                            siblingLoc[0] + sibling.width,
+                            siblingLoc[1] + sibling.height,
+                        )
+                    if (sibRect.contains(screenX, screenY)) return true
+                }
 
                 // Check descendants — catches overflow (e.g. a card with
                 // negative margin extending outside its parent's bounds)


### PR DESCRIPTION
## Problem

Touches that land inside a `SandboxReactNativeView` are silently dropped in **debug** builds — the sandbox content renders but is completely untappable (taps *and* scrolls). The exact same build works in **release**, which makes it easy to dismiss as flaky or environment-specific.

## Root cause

`SandboxTouchInterceptor.isObscuredAt` decides whether a sandbox is covered by an overlay using only the sibling's **visibility + screen bounds** — it never checks `pointerEvents`.

In dev, React Native's `AppContainer` mounts a **full-screen `pointerEvents="box-none"` overlay** (for LogBox and the element inspector), drawn on top of the whole app. Visually it's transparent to touch, but `isObscuredAt` sees a visible, full-screen sibling drawn after the sandbox and reports it as obscuring. The interceptor then takes the `redispatchWithHiddenSandbox` path: it hides the sandbox surface and re-dispatches through the normal pipeline, so the event lands on the (empty) host behind it instead of the sandbox. Result: every touch in the sandbox is stolen.

Release has no such overlay, so it only reproduces in debug — which is why it's easy to miss.

## Repro

1. Embed a `SandboxReactNativeView` with any tappable content in a **debug** build (New Arch / bridgeless, RN 0.85).
2. Tap/scroll inside the sandbox → nothing happens.
3. Same build in **release** → works.

(Confirmed by logging `isObscuredAt`: it returns the AppContainer's `ReactViewGroup` — a full-screen `box-none` view drawn after the sandbox.)

## Fix

In `isObscuredAt`, respect `pointerEvents`:
- `NONE` → fully transparent to touch; skip the sibling entirely.
- `BOX_NONE` → its own box passes touch through (only its children can catch); skip the own-bounds test but still check descendants.

Three lines, no behavior change for real overlays (Modals etc. keep `pointerEvents` auto). Follow-up to #33, which introduced the interceptor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)