### PR TITLE
fix(ci): fix android emulator OOM on CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -199,11 +199,14 @@ jobs:
         working-directory: apps/fs-experiment
         run: npx react-native build-android --tasks assembleDebug
 
+      - name: Stop Gradle daemon
+        run: ./apps/fs-experiment/android/gradlew --stop
+
       - name: Run emulator and harness tests
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
           api-level: 35
-          target: google_apis
+          target: default
           arch: x86_64
           avd-name: test_device
           force-avd-creation: true


### PR DESCRIPTION
## Summary

- Switch `target: google_apis` → `target: default` — AOSP image doesn't bundle Play Services, uses ~600MB less RAM and boots faster. Harness tests don't need Play Services.
- Add `./gradlew --stop` before launching the emulator — kills the resident Gradle daemon after the build, freeing ~1GB of heap before the emulator claims its 2560MB.

## Root cause

The emulator process was silently OOM-killed immediately after launch — it never responded to a single `adb` poll over the full 600s boot timeout. The `google_apis` image bumped RAM to 2560MB, and with two live Gradle/Java daemons still running after the build step, the 7GB ubuntu-latest runner had insufficient memory left.

## Test plan

- [ ] `harness-android` job boots emulator and completes without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)