### PR TITLE
fix(android): actually download remote http(s) jsBundleSource

### DIFF
--- a/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
+++ b/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
@@ -273,72 +273,52 @@ class SandboxReactNativeDelegate(
         if (bundleSource.isEmpty()) return null
         return when {
             bundleSource.startsWith("http://") || bundleSource.startsWith("https://") -> {
-                // JSBundleLoader.createFileLoader(url) does not download anything:
-                // loadScriptFromFile treats the argument as a local path, so a remote
-                // URL never resolves. Prefetch the bundle to a cache file (off the main
-                // thread to avoid NetworkOnMainThreadException) and hand it to the
-                // network loader, which keeps the original sourceURL for stack traces.
-                //
-                // The cache file is keyed by the URL, and a remote URL is treated as
-                // immutable: if it was already downloaded, reuse the cached copy and
-                // skip the network entirely. This makes repeated loads (e.g. every cold
-                // start) instant and offline-capable. To ship an update, change the URL
-                // (a version segment or `?v=` query) — a new URL misses the cache and is
-                // fetched once. Serving changing content at a fixed URL won't update.
-                val cacheFile = File(
-                    context.cacheDir,
-                    "sandbox-remote-${bundleSource.hashCode()}.bundle",
-                )
-                if (cacheFile.exists() && cacheFile.length() > 0L) {
-                    Log.d(TAG, "Reusing cached bundle '$bundleSource' (${cacheFile.length()} bytes)")
-                } else {
-                    var downloadError: Exception? = null
-                    val worker = Thread {
-                        try {
-                            val connection = URL(bundleSource).openConnection() as HttpURLConnection
-                            connection.connectTimeout = REMOTE_BUNDLE_CONNECT_TIMEOUT_MS
-                            connection.readTimeout = REMOTE_BUNDLE_READ_TIMEOUT_MS
-                            try {
-                                connection.inputStream.use { input ->
-                                    cacheFile.outputStream().use { output -> input.copyTo(output) }
-                                }
-                            } finally {
-                                connection.disconnect()
-                            }
-                        } catch (e: Exception) {
-                            downloadError = e
-                        }
-                    }
-                    worker.start()
-                    worker.join(REMOTE_BUNDLE_DOWNLOAD_TIMEOUT_MS)
-                    if (downloadError != null || !cacheFile.exists() || cacheFile.length() == 0L) {
-                        // Drop a partial file so a later load can retry cleanly.
-                        cacheFile.delete()
-                        Log.e(TAG, "Failed to download remote bundle '$bundleSource'", downloadError)
-                        return null
-                    }
-                    Log.d(TAG, "Downloaded remote bundle '$bundleSource' (${cacheFile.length()} bytes)")
-                }
-                // Load the cached bundle synchronously (loadSynchronously = true).
-                // createCachedBundleFromNetworkLoader() loads with loadSynchronously
-                // = false, which on RN 0.85 bridgeless executes the script before the
-                // TurboModule JSI bindings are installed on the runtime — the bundle's
-                // InitializeCore then hits TurboModuleRegistry.getEnforcing('Platform-
-                // Constants') with no proxy registered and the VM aborts. A synchronous
-                // load mirrors how the built-in asset loader (createAssetLoader(.., true))
-                // runs the main bundle, which sequences correctly. We keep the original
-                // URL as sourceURL so stack traces still point at the remote bundle.
-                JSBundleLoader.createFileLoader(
-                    cacheFile.absolutePath,
-                    bundleSource,
-                    true,
-                )
+                // createFileLoader(url) treats its argument as a local path and never
+                // downloads. Prefetch to a cache file on a worker thread instead.
+                val cacheFile = downloadRemoteBundle(bundleSource) ?: return null
+                // Load synchronously: on RN 0.85 bridgeless an async load executes the
+                // bundle before TurboModule JSI bindings are installed, causing a fatal.
+                JSBundleLoader.createFileLoader(cacheFile.absolutePath, bundleSource, true)
             }
 
             else -> {
                 JSBundleLoader.createAssetLoader(context, "assets://$bundleSource", true)
             }
         }
+    }
+
+    private fun downloadRemoteBundle(bundleSource: String): File? {
+        val cacheFile = File(context.cacheDir, "sandbox-remote-${bundleSource.hashCode()}.bundle")
+        if (cacheFile.exists() && cacheFile.length() > 0L) {
+            Log.d(TAG, "Reusing cached bundle '$bundleSource' (${cacheFile.length()} bytes)")
+            return cacheFile
+        }
+        var downloadError: Exception? = null
+        val worker = Thread {
+            try {
+                val connection = URL(bundleSource).openConnection() as HttpURLConnection
+                connection.connectTimeout = REMOTE_BUNDLE_CONNECT_TIMEOUT_MS
+                connection.readTimeout = REMOTE_BUNDLE_READ_TIMEOUT_MS
+                try {
+                    connection.inputStream.use { input ->
+                        cacheFile.outputStream().use { output -> input.copyTo(output) }
+                    }
+                } finally {
+                    connection.disconnect()
+                }
+            } catch (e: Exception) {
+                downloadError = e
+            }
+        }
+        worker.start()
+        worker.join(REMOTE_BUNDLE_DOWNLOAD_TIMEOUT_MS)
+        if (downloadError != null || !cacheFile.exists() || cacheFile.length() == 0L) {
+            cacheFile.delete()
+            Log.e(TAG, "Failed to download remote bundle '$bundleSource'", downloadError)
+            return null
+        }
+        Log.d(TAG, "Downloaded remote bundle '$bundleSource' (${cacheFile.length()} bytes)")
+        return cacheFile
     }
 
     fun onJSIBindingsInstalled(stateHandle: Long) {

--- a/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
+++ b/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
@@ -178,8 +178,9 @@ class SandboxReactNativeDelegate(
                 // and fetches the bundle from the Metro dev server using jsMainModulePath,
                 // turning the URL into http://localhost:8081/<url>.bundle (a 404). Local
                 // sources ("index"/asset names) keep dev support so Fast Refresh works.
-                val isRemoteBundle = capturedBundleSource.startsWith("http://") ||
-                    capturedBundleSource.startsWith("https://")
+                val isRemoteBundle =
+                    capturedBundleSource.startsWith("http://") ||
+                        capturedBundleSource.startsWith("https://")
                 host =
                     ReactHostImpl(
                         sandboxContext,
@@ -294,22 +295,23 @@ class SandboxReactNativeDelegate(
             return cacheFile
         }
         var downloadError: Exception? = null
-        val worker = Thread {
-            try {
-                val connection = URL(bundleSource).openConnection() as HttpURLConnection
-                connection.connectTimeout = REMOTE_BUNDLE_CONNECT_TIMEOUT_MS
-                connection.readTimeout = REMOTE_BUNDLE_READ_TIMEOUT_MS
+        val worker =
+            Thread {
                 try {
-                    connection.inputStream.use { input ->
-                        cacheFile.outputStream().use { output -> input.copyTo(output) }
+                    val connection = URL(bundleSource).openConnection() as HttpURLConnection
+                    connection.connectTimeout = REMOTE_BUNDLE_CONNECT_TIMEOUT_MS
+                    connection.readTimeout = REMOTE_BUNDLE_READ_TIMEOUT_MS
+                    try {
+                        connection.inputStream.use { input ->
+                            cacheFile.outputStream().use { output -> input.copyTo(output) }
+                        }
+                    } finally {
+                        connection.disconnect()
                     }
-                } finally {
-                    connection.disconnect()
+                } catch (e: Exception) {
+                    downloadError = e
                 }
-            } catch (e: Exception) {
-                downloadError = e
             }
-        }
         worker.start()
         worker.join(REMOTE_BUNDLE_DOWNLOAD_TIMEOUT_MS)
         if (downloadError != null || !cacheFile.exists() || cacheFile.length() == 0L) {

--- a/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
+++ b/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
@@ -278,34 +278,47 @@ class SandboxReactNativeDelegate(
                 // URL never resolves. Prefetch the bundle to a cache file (off the main
                 // thread to avoid NetworkOnMainThreadException) and hand it to the
                 // network loader, which keeps the original sourceURL for stack traces.
+                //
+                // The cache file is keyed by the URL, and a remote URL is treated as
+                // immutable: if it was already downloaded, reuse the cached copy and
+                // skip the network entirely. This makes repeated loads (e.g. every cold
+                // start) instant and offline-capable. To ship an update, change the URL
+                // (a version segment or `?v=` query) — a new URL misses the cache and is
+                // fetched once. Serving changing content at a fixed URL won't update.
                 val cacheFile = File(
                     context.cacheDir,
                     "sandbox-remote-${bundleSource.hashCode()}.bundle",
                 )
-                var downloadError: Exception? = null
-                val worker = Thread {
-                    try {
-                        val connection = URL(bundleSource).openConnection() as HttpURLConnection
-                        connection.connectTimeout = REMOTE_BUNDLE_CONNECT_TIMEOUT_MS
-                        connection.readTimeout = REMOTE_BUNDLE_READ_TIMEOUT_MS
+                if (cacheFile.exists() && cacheFile.length() > 0L) {
+                    Log.d(TAG, "Reusing cached bundle '$bundleSource' (${cacheFile.length()} bytes)")
+                } else {
+                    var downloadError: Exception? = null
+                    val worker = Thread {
                         try {
-                            connection.inputStream.use { input ->
-                                cacheFile.outputStream().use { output -> input.copyTo(output) }
+                            val connection = URL(bundleSource).openConnection() as HttpURLConnection
+                            connection.connectTimeout = REMOTE_BUNDLE_CONNECT_TIMEOUT_MS
+                            connection.readTimeout = REMOTE_BUNDLE_READ_TIMEOUT_MS
+                            try {
+                                connection.inputStream.use { input ->
+                                    cacheFile.outputStream().use { output -> input.copyTo(output) }
+                                }
+                            } finally {
+                                connection.disconnect()
                             }
-                        } finally {
-                            connection.disconnect()
+                        } catch (e: Exception) {
+                            downloadError = e
                         }
-                    } catch (e: Exception) {
-                        downloadError = e
                     }
+                    worker.start()
+                    worker.join(REMOTE_BUNDLE_DOWNLOAD_TIMEOUT_MS)
+                    if (downloadError != null || !cacheFile.exists() || cacheFile.length() == 0L) {
+                        // Drop a partial file so a later load can retry cleanly.
+                        cacheFile.delete()
+                        Log.e(TAG, "Failed to download remote bundle '$bundleSource'", downloadError)
+                        return null
+                    }
+                    Log.d(TAG, "Downloaded remote bundle '$bundleSource' (${cacheFile.length()} bytes)")
                 }
-                worker.start()
-                worker.join(REMOTE_BUNDLE_DOWNLOAD_TIMEOUT_MS)
-                if (downloadError != null || !cacheFile.exists() || cacheFile.length() == 0L) {
-                    Log.e(TAG, "Failed to download remote bundle '$bundleSource'", downloadError)
-                    return null
-                }
-                Log.d(TAG, "Downloaded remote bundle '$bundleSource' (${cacheFile.length()} bytes)")
                 JSBundleLoader.createCachedBundleFromNetworkLoader(
                     bundleSource,
                     cacheFile.absolutePath,

--- a/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
+++ b/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
@@ -27,12 +27,19 @@ import com.facebook.react.runtime.ReactHostImpl
 import com.facebook.react.runtime.hermes.HermesInstance
 import com.facebook.react.shell.MainReactPackage
 import com.facebook.react.uimanager.ViewManager
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
 
 class SandboxReactNativeDelegate(
     private val context: Context,
 ) {
     companion object {
         private const val TAG = "SandboxRNDelegate"
+
+        private const val REMOTE_BUNDLE_CONNECT_TIMEOUT_MS = 10_000
+        private const val REMOTE_BUNDLE_READ_TIMEOUT_MS = 15_000
+        private const val REMOTE_BUNDLE_DOWNLOAD_TIMEOUT_MS = 20_000L
 
         private val sharedHosts = mutableMapOf<String, SharedReactHost>()
         private val registeredSubstitutionPackages = mutableListOf<ReactPackage>()
@@ -166,13 +173,20 @@ class SandboxReactNativeDelegate(
                 val componentFactory = ComponentFactory()
                 DefaultComponentsRegistry.register(componentFactory)
 
+                // For a remote (http/https) bundle, disable developer support on this
+                // ReactHost. With dev support enabled the runtime ignores jsBundleLoader
+                // and fetches the bundle from the Metro dev server using jsMainModulePath,
+                // turning the URL into http://localhost:8081/<url>.bundle (a 404). Local
+                // sources ("index"/asset names) keep dev support so Fast Refresh works.
+                val isRemoteBundle = capturedBundleSource.startsWith("http://") ||
+                    capturedBundleSource.startsWith("https://")
                 host =
                     ReactHostImpl(
                         sandboxContext,
                         hostDelegate,
                         componentFactory,
-                        true,
-                        true,
+                        !isRemoteBundle,
+                        !isRemoteBundle,
                     )
 
                 ownsReactHost = true
@@ -259,7 +273,43 @@ class SandboxReactNativeDelegate(
         if (bundleSource.isEmpty()) return null
         return when {
             bundleSource.startsWith("http://") || bundleSource.startsWith("https://") -> {
-                JSBundleLoader.createFileLoader(bundleSource)
+                // JSBundleLoader.createFileLoader(url) does not download anything:
+                // loadScriptFromFile treats the argument as a local path, so a remote
+                // URL never resolves. Prefetch the bundle to a cache file (off the main
+                // thread to avoid NetworkOnMainThreadException) and hand it to the
+                // network loader, which keeps the original sourceURL for stack traces.
+                val cacheFile = File(
+                    context.cacheDir,
+                    "sandbox-remote-${bundleSource.hashCode()}.bundle",
+                )
+                var downloadError: Exception? = null
+                val worker = Thread {
+                    try {
+                        val connection = URL(bundleSource).openConnection() as HttpURLConnection
+                        connection.connectTimeout = REMOTE_BUNDLE_CONNECT_TIMEOUT_MS
+                        connection.readTimeout = REMOTE_BUNDLE_READ_TIMEOUT_MS
+                        try {
+                            connection.inputStream.use { input ->
+                                cacheFile.outputStream().use { output -> input.copyTo(output) }
+                            }
+                        } finally {
+                            connection.disconnect()
+                        }
+                    } catch (e: Exception) {
+                        downloadError = e
+                    }
+                }
+                worker.start()
+                worker.join(REMOTE_BUNDLE_DOWNLOAD_TIMEOUT_MS)
+                if (downloadError != null || !cacheFile.exists() || cacheFile.length() == 0L) {
+                    Log.e(TAG, "Failed to download remote bundle '$bundleSource'", downloadError)
+                    return null
+                }
+                Log.d(TAG, "Downloaded remote bundle '$bundleSource' (${cacheFile.length()} bytes)")
+                JSBundleLoader.createCachedBundleFromNetworkLoader(
+                    bundleSource,
+                    cacheFile.absolutePath,
+                )
             }
 
             else -> {

--- a/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
+++ b/packages/react-native-sandbox/android/src/main/java/io/callstack/rnsandbox/SandboxReactNativeDelegate.kt
@@ -319,9 +319,19 @@ class SandboxReactNativeDelegate(
                     }
                     Log.d(TAG, "Downloaded remote bundle '$bundleSource' (${cacheFile.length()} bytes)")
                 }
-                JSBundleLoader.createCachedBundleFromNetworkLoader(
-                    bundleSource,
+                // Load the cached bundle synchronously (loadSynchronously = true).
+                // createCachedBundleFromNetworkLoader() loads with loadSynchronously
+                // = false, which on RN 0.85 bridgeless executes the script before the
+                // TurboModule JSI bindings are installed on the runtime — the bundle's
+                // InitializeCore then hits TurboModuleRegistry.getEnforcing('Platform-
+                // Constants') with no proxy registered and the VM aborts. A synchronous
+                // load mirrors how the built-in asset loader (createAssetLoader(.., true))
+                // runs the main bundle, which sequences correctly. We keep the original
+                // URL as sourceURL so stack traces still point at the remote bundle.
+                JSBundleLoader.createFileLoader(
                     cacheFile.absolutePath,
+                    bundleSource,
+                    true,
                 )
             }
 


### PR DESCRIPTION
Supersedes #37 — incorporates all of @akelmanson's work with review feedback applied.

## Summary

Loading a sandbox from a remote URL (`jsBundleSource="https://…/x.bundle"`) did not work on Android. Two issues compounded:

1. **The URL was never downloaded.** `createBundleLoader` mapped an `http(s)` source to `JSBundleLoader.createFileLoader(url)`, which treats its argument as a local file path — a remote URL never resolves.
2. **Dev support hijacked the load.** In debug builds, `ReactHostImpl` with dev support enabled ignores `jsBundleLoader` and fetches through Metro, mangling the URL into `http://localhost:8081/http://host/x.bundle.bundle` → 404.

## Fix

- Prefetch the remote bundle to a cache file on a worker thread (avoids `NetworkOnMainThreadException`), then load it via `JSBundleLoader.createFileLoader(cacheFile, sourceUrl, true)` — synchronous load required on RN 0.85 bridgeless to sequence after TurboModule JSI bindings
- Disable developer support for remote `http(s)` sources so Metro doesn't intercept the load
- Extract download logic into `downloadRemoteBundle()` private function
- Cache is keyed by URL hash — same URL reuses the cached copy; change the URL to force a re-fetch

## Changes from #37

- Extracted download block into `downloadRemoteBundle()` (requested by @CAMOBAP)
- Shortened both inline comments to 2 lines (requested by @CAMOBAP)

Co-authored-by: akelmanson <akelmanson@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)